### PR TITLE
DH params for E-series

### DIFF
--- a/ur_kinematics/CMakeLists.txt
+++ b/ur_kinematics/CMakeLists.txt
@@ -12,7 +12,7 @@ catkin_python_setup()
 
 catkin_package(
   INCLUDE_DIRS include
-  LIBRARIES ur3_kin ur5_kin ur10_kin ur3_moveit_plugin ur5_moveit_plugin ur10_moveit_plugin
+  LIBRARIES ur3_kin ur3e_kin ur5_kin ur5e_kin ur10_kin ur103_kin ur3_moveit_plugin ur3e_moveit_plugin ur5_moveit_plugin ur5e_moveit_plugin ur10_moveit_plugin ur10e_moveit_plugin
   CATKIN_DEPENDS roscpp geometry_msgs moveit_core moveit_kinematics moveit_ros_planning
     pluginlib tf_conversions
   DEPENDS Boost
@@ -29,11 +29,20 @@ include_directories(include ${catkin_INCLUDE_DIRS})
 add_library(ur3_kin src/ur_kin.cpp)
 set_target_properties(ur3_kin PROPERTIES COMPILE_DEFINITIONS "UR3_PARAMS")
 
+add_library(ur3e_kin src/ur_kin.cpp)
+set_target_properties(ur3e_kin PROPERTIES COMPILE_DEFINITIONS "UR3E_PARAMS")
+
 add_library(ur5_kin src/ur_kin.cpp)
 set_target_properties(ur5_kin PROPERTIES COMPILE_DEFINITIONS "UR5_PARAMS")
 
+add_library(ur5e_kin src/ur_kin.cpp)
+set_target_properties(ur5e_kin PROPERTIES COMPILE_DEFINITIONS "UR5E_PARAMS")
+
 add_library(ur10_kin src/ur_kin.cpp)
 set_target_properties(ur10_kin PROPERTIES COMPILE_DEFINITIONS "UR10_PARAMS")
+
+add_library(ur10e_kin src/ur_kin.cpp)
+set_target_properties(ur10e_kin PROPERTIES COMPILE_DEFINITIONS "UR10E_PARAMS")
 
 
 add_library(ur3_moveit_plugin src/ur_moveit_plugin.cpp)
@@ -43,12 +52,26 @@ target_link_libraries(ur3_moveit_plugin
   ${Boost_LIBRARIES}
   ur3_kin)
 
+add_library(ur3e_moveit_plugin src/ur_moveit_plugin.cpp)
+set_target_properties(ur3e_moveit_plugin PROPERTIES COMPILE_DEFINITIONS "UR3E_PARAMS")
+target_link_libraries(ur3e_moveit_plugin
+        ${catkin_LIBRARIES}
+        ${Boost_LIBRARIES}
+        ur3e_kin)
+
 add_library(ur5_moveit_plugin src/ur_moveit_plugin.cpp)
 set_target_properties(ur5_moveit_plugin PROPERTIES COMPILE_DEFINITIONS "UR5_PARAMS")
 target_link_libraries(ur5_moveit_plugin
   ${catkin_LIBRARIES}
   ${Boost_LIBRARIES}
   ur5_kin)
+
+add_library(ur5e_moveit_plugin src/ur_moveit_plugin.cpp)
+set_target_properties(ur5e_moveit_plugin PROPERTIES COMPILE_DEFINITIONS "UR5E_PARAMS")
+target_link_libraries(ur5e_moveit_plugin
+        ${catkin_LIBRARIES}
+        ${Boost_LIBRARIES}
+        ur5e_kin)
 
 add_library(ur10_moveit_plugin src/ur_moveit_plugin.cpp)
 set_target_properties(ur10_moveit_plugin PROPERTIES COMPILE_DEFINITIONS "UR10_PARAMS")
@@ -57,12 +80,19 @@ target_link_libraries(ur10_moveit_plugin
   ${Boost_LIBRARIES}
   ur10_kin)
 
+add_library(ur10e_moveit_plugin src/ur_moveit_plugin.cpp)
+set_target_properties(ur10e_moveit_plugin PROPERTIES COMPILE_DEFINITIONS "UR10E_PARAMS")
+target_link_libraries(ur10e_moveit_plugin
+        ${catkin_LIBRARIES}
+        ${Boost_LIBRARIES}
+        ur10e_kin)
+
 
 #############
 ## Install ##
 #############
 
-install(TARGETS ur3_kin ur5_kin ur10_kin ur3_moveit_plugin ur5_moveit_plugin ur10_moveit_plugin
+install(TARGETS ur3_kin ur3e_kin ur5_kin ur5e_kin ur10_kin ur10e_kin ur3_moveit_plugin ur3e_moveit_plugin ur5_moveit_plugin ur5e_moveit_plugin ur10_moveit_plugin ur10e_moveit_plugin
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}

--- a/ur_kinematics/src/ur_kin.cpp
+++ b/ur_kinematics/src/ur_kin.cpp
@@ -23,6 +23,16 @@ namespace ur_kinematics {
     const double d6 =  0.0922;
     #endif
 
+    //#define UR10E_PARAMS
+    #ifdef UR10E_PARAMS
+    const double d1 =  0.1807;
+    const double a2 = -0.6127;
+    const double a3 = -0.57155;
+    const double d4 =  0.17415;
+    const double d5 =  0.11985;
+    const double d6 =  0.11655;
+    #endif
+
     //#define UR5_PARAMS
     #ifdef UR5_PARAMS
     const double d1 =  0.089159;
@@ -31,6 +41,16 @@ namespace ur_kinematics {
     const double d4 =  0.10915;
     const double d5 =  0.09465;
     const double d6 =  0.0823;
+    #endif
+
+    //#define UR5E_PARAMS
+    #ifdef UR5E_PARAMS
+    const double d1 =  0.1625;
+    const double a2 = -0.42500;
+    const double a3 = -0.39225;
+    const double d4 =  0.1333;
+    const double d5 =  0.0997;
+    const double d6 =  0.0996;
     #endif
     
     //#define UR3_PARAMS
@@ -41,6 +61,16 @@ namespace ur_kinematics {
     const double d4 =  0.11235;
     const double d5 =  0.08535;
     const double d6 =  0.0819;
+    #endif
+
+    //#define UR3E_PARAMS
+    #ifdef UR3E_PARAMS
+    const double d1 =  0.15185;
+    const double a2 = -0.24355;
+    const double a3 = -0.2132;
+    const double d4 =  0.13105;
+    const double d5 =  0.08535;
+    const double d6 =  0.0921;
     #endif
   }
 

--- a/ur_kinematics/ur_moveit_plugins.xml
+++ b/ur_kinematics/ur_moveit_plugins.xml
@@ -8,6 +8,16 @@
   </class>
 </library>
 
+<library path="lib/libur3e_moveit_plugin">
+<class name="ur_kinematics/UR3eKinematicsPlugin" type="ur_kinematics::URKinematicsPlugin" base_class_type="kinematics::KinematicsBase">
+  <description>
+    Analytic kinematics for the Universal Robots UR3e.
+    Developed by Kelsey Hawkins from Georgia Tech.
+    See http://hdl.handle.net/1853/50782 for details.
+  </description>
+</class>
+</library>
+
 <library path="lib/libur5_moveit_plugin">
   <class name="ur_kinematics/UR5KinematicsPlugin" type="ur_kinematics::URKinematicsPlugin" base_class_type="kinematics::KinematicsBase">
     <description>
@@ -16,6 +26,16 @@
       See http://hdl.handle.net/1853/50782 for details.
     </description>
   </class>
+</library>
+
+<library path="lib/libur5e_moveit_plugin">
+<class name="ur_kinematics/UR5eKinematicsPlugin" type="ur_kinematics::URKinematicsPlugin" base_class_type="kinematics::KinematicsBase">
+  <description>
+    Analytic kinematics for the Universal Robots UR5e.
+    Developed by Kelsey Hawkins from Georgia Tech.
+    See http://hdl.handle.net/1853/50782 for details.
+  </description>
+</class>
 </library>
 
 <library path="lib/libur10_moveit_plugin">
@@ -27,3 +47,14 @@
     </description>
   </class>
 </library>
+
+<library path="lib/libur10e_moveit_plugin">
+<class name="ur_kinematics/UR10eKinematicsPlugin" type="ur_kinematics::URKinematicsPlugin" base_class_type="kinematics::KinematicsBase">
+  <description>
+    Analytic kinematics for the Universal Robots UR10e.
+    Developed by Kelsey Hawkins from Georgia Tech.
+    See http://hdl.handle.net/1853/50782 for details.
+  </description>
+</class>
+</library>
+


### PR DESCRIPTION
* Updated DH params for E-Series robots 
* Set of of new packages is created for different models, e.g. `ur3e_kin`, `ur3e_moveit_plugin`, etc 
* MoveIt plugin names are: `ur_kinematics/UR3eKinematicsPlugin`, `ur_kinematics/UR5eKinematicsPlugin`, `ur_kinematics/UR10eKinematicsPlugin`